### PR TITLE
Hide an image in Spotity Connect dialog box and change hover color

### DIFF
--- a/color.ini
+++ b/color.ini
@@ -14,5 +14,5 @@ pressing_button_fg                    = 5294E2
 pressing_button_bg                    = 303642
 selected_button                       = 5294E2
 miscellaneous_bg                      = 303642
-miscellaneous_hover_bg                = FFFFFF
+miscellaneous_hover_bg                = 303642
 preserve_1                            = FFFFFF

--- a/user.css
+++ b/user.css
@@ -4,3 +4,7 @@
 	width: 0px !important;
 	background-color: transparent;
 }
+
+.ConnectPopup__devices-image {
+	display: none;
+}


### PR DESCRIPTION
Hey.

I've recently discovered Spicetify and your theme. It looks great, I'm very satisfied with how well Spotify blends into my desktop theme right now.

There were two things that seemed off to me - I decided to hide the image in Spotity Connect (background thereof is not transparent and it looks really nasty) and changed hover color.

Please let me know what you think!